### PR TITLE
fix: disable i18n api translations

### DIFF
--- a/i18n/localeDetector.ts
+++ b/i18n/localeDetector.ts
@@ -1,9 +1,0 @@
-export default defineI18nLocaleDetector((event, config) => {
-  const cookie = tryCookieLocale(event, { lang: '', name: 'i18n_redirected' });
-  if (cookie) return cookie.toString();
-
-  const header = tryHeaderLocale(event, { lang: '' });
-  if (header) return header.toString();
-
-  return config.defaultLocale;
-});

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,9 +34,6 @@ export default defineNuxtConfig({
     lazy: true,
     defaultLocale: 'en',
     locales,
-    experimental: {
-      localeDetector: 'localeDetector.ts'
-    },
     bundle: {
       optimizeTranslationDirective: false
     }

--- a/server/middleware/i18n.ts
+++ b/server/middleware/i18n.ts
@@ -1,3 +1,0 @@
-export default defineEventHandler(async (event) => {
-  event.context.$t = await useTranslation(event);
-});


### PR DESCRIPTION
- fix: disable i18n api translations
due to i18n api cache error & prod not showing up api messages in error pages